### PR TITLE
Add in-memory DepositStore

### DIFF
--- a/cmd/opencxd/opencxd.go
+++ b/cmd/opencxd/opencxd.go
@@ -172,8 +172,14 @@ func main() {
 
 	logging.Infof("Creating deposit stores...")
 	var depositStores map[*coinparam.Params]cxdb.DepositStore
-	if depositStores, err = cxdbsql.CreateDepositStoreMap(coinList); err != nil {
-		logging.Fatalf("Error creating deposit store map for opencxd: %s", err)
+	if len(conf.Whitelist) != 0 {
+		if depositStores, err = cxdbmemory.CreateDepositStoreMap(coinList); err != nil {
+			logging.Fatalf("Error creating deposit store map for opencxd: %s", err)
+		}
+	} else {
+		if depositStores, err = cxdbsql.CreateDepositStoreMap(coinList); err != nil {
+			logging.Fatalf("Error creating deposit store map for opencxd: %s", err)
+		}
 	}
 
 	logging.Infof("Creating settlement stores...")

--- a/cxbenchmark/serversetup.go
+++ b/cxbenchmark/serversetup.go
@@ -64,7 +64,7 @@ func createLightSettleServer(coinList []*coinparam.Params, whitelist []*koblitz.
 	}
 
 	var depositStores map[*coinparam.Params]cxdb.DepositStore
-	if depositStores, err = cxdbsql.CreateDepositStoreMap(coinList); err != nil {
+	if depositStores, err = cxdbmemory.CreateDepositStoreMap(coinList); err != nil {
 		err = fmt.Errorf("Error creating deposit store map for createFullServer: %s", err)
 		return
 	}
@@ -270,7 +270,7 @@ func createFullServer(coinList []*coinparam.Params, serverhost string, serverpor
 	}
 
 	var depositStores map[*coinparam.Params]cxdb.DepositStore
-	if depositStores, err = cxdbsql.CreateDepositStoreMap(coinList); err != nil {
+	if depositStores, err = cxdbmemory.CreateDepositStoreMap(coinList); err != nil {
 		err = fmt.Errorf("Error creating deposit store map for createFullServer: %s", err)
 		return
 	}

--- a/cxdb/cxdbmemory/depositstore.go
+++ b/cxdb/cxdbmemory/depositstore.go
@@ -1,0 +1,131 @@
+package cxdbmemory
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/mit-dci/lit/coinparam"
+	"github.com/mit-dci/lit/crypto/koblitz"
+	"github.com/mit-dci/opencx/cxdb"
+	"github.com/mit-dci/opencx/match"
+)
+
+type pendingDeposit struct {
+	pubkey  [33]byte
+	amount  uint64
+	confirm uint64
+}
+
+// MemoryDepositStore is a simple in-memory implementation of cxdb.DepositStore
+// used for development and testing without a SQL database.
+type MemoryDepositStore struct {
+	coin *coinparam.Params
+
+	addrToPub map[string]*koblitz.PublicKey
+	pubToAddr map[[33]byte]string
+	pending   map[uint64][]pendingDeposit
+
+	mtx *sync.Mutex
+}
+
+// CreateDepositStore creates a deposit store for a specific coin.
+func CreateDepositStore(coin *coinparam.Params) (store cxdb.DepositStore, err error) {
+	md := &MemoryDepositStore{
+		coin:      coin,
+		addrToPub: make(map[string]*koblitz.PublicKey),
+		pubToAddr: make(map[[33]byte]string),
+		pending:   make(map[uint64][]pendingDeposit),
+		mtx:       new(sync.Mutex),
+	}
+	store = md
+	return
+}
+
+// CreateDepositStoreMap creates a map of coin to deposit store for a list of coins.
+func CreateDepositStoreMap(coinList []*coinparam.Params) (depositMap map[*coinparam.Params]cxdb.DepositStore, err error) {
+	depositMap = make(map[*coinparam.Params]cxdb.DepositStore)
+	var cur cxdb.DepositStore
+	for _, coin := range coinList {
+		if cur, err = CreateDepositStore(coin); err != nil {
+			return
+		}
+		depositMap[coin] = cur
+	}
+	return
+}
+
+// RegisterUser associates a pubkey with a deposit address.
+func (md *MemoryDepositStore) RegisterUser(pubkey *koblitz.PublicKey, address string) (err error) {
+	md.mtx.Lock()
+	defer md.mtx.Unlock()
+
+	var pk [33]byte
+	copy(pk[:], pubkey.SerializeCompressed())
+	md.pubToAddr[pk] = address
+	md.addrToPub[address] = pubkey
+	return
+}
+
+// UpdateDeposits updates pending deposits and returns settlement executions for
+// deposits that mature at the provided block height.
+func (md *MemoryDepositStore) UpdateDeposits(deposits []match.Deposit, blockheight uint64) (depositExecs []*match.SettlementExecution, err error) {
+	var asset match.Asset
+	if asset, err = match.AssetFromCoinParam(md.coin); err != nil {
+		err = fmt.Errorf("Error getting asset from coin param for UpdateDeposits: %s", err)
+		return
+	}
+
+	md.mtx.Lock()
+	defer md.mtx.Unlock()
+
+	// record new deposits
+	for _, dep := range deposits {
+		exp := dep.BlockHeightReceived + dep.Confirmations
+		var pd pendingDeposit
+		copy(pd.pubkey[:], dep.Pubkey.SerializeCompressed())
+		pd.amount = dep.Amount
+		pd.confirm = exp
+		md.pending[exp] = append(md.pending[exp], pd)
+	}
+
+	if list, ok := md.pending[blockheight]; ok {
+		for _, pd := range list {
+			exec := &match.SettlementExecution{
+				Pubkey: pd.pubkey,
+				Amount: pd.amount,
+				Asset:  asset,
+				Type:   match.Debit,
+			}
+			depositExecs = append(depositExecs, exec)
+		}
+		delete(md.pending, blockheight)
+	}
+
+	return
+}
+
+// GetDepositAddressMap returns a copy of the address to pubkey map.
+func (md *MemoryDepositStore) GetDepositAddressMap() (depAddrMap map[string]*koblitz.PublicKey, err error) {
+	md.mtx.Lock()
+	defer md.mtx.Unlock()
+
+	depAddrMap = make(map[string]*koblitz.PublicKey)
+	for addr, pk := range md.addrToPub {
+		depAddrMap[addr] = pk
+	}
+	return
+}
+
+// GetDepositAddress gets the deposit address for a pubkey.
+func (md *MemoryDepositStore) GetDepositAddress(pubkey *koblitz.PublicKey) (addr string, err error) {
+	md.mtx.Lock()
+	defer md.mtx.Unlock()
+
+	var pk [33]byte
+	copy(pk[:], pubkey.SerializeCompressed())
+	var ok bool
+	if addr, ok = md.pubToAddr[pk]; !ok {
+		err = fmt.Errorf("address not found for pubkey")
+	}
+	return
+}

--- a/cxdb/cxdbmemory/depositstore_test.go
+++ b/cxdb/cxdbmemory/depositstore_test.go
@@ -1,0 +1,80 @@
+package cxdbmemory
+
+import (
+	"testing"
+
+	"github.com/mit-dci/lit/coinparam"
+	"github.com/mit-dci/lit/crypto/koblitz"
+	"github.com/mit-dci/opencx/match"
+)
+
+func TestMemoryDepositStoreRegisterAndRetrieve(t *testing.T) {
+	store, err := CreateDepositStore(&coinparam.BitcoinParams)
+	if err != nil {
+		t.Fatalf("create store err: %v", err)
+	}
+
+	priv, _ := koblitz.PrivKeyFromBytes(koblitz.S256(), []byte{1})
+	pub := priv.PubKey()
+	addr := "addr1"
+
+	if err = store.RegisterUser(pub, addr); err != nil {
+		t.Fatalf("register user: %v", err)
+	}
+
+	if got, err := store.GetDepositAddress(pub); err != nil || got != addr {
+		t.Fatalf("get deposit address mismatch: %v %s", err, got)
+	}
+
+	m, err := store.GetDepositAddressMap()
+	if err != nil {
+		t.Fatalf("get deposit map: %v", err)
+	}
+	if m[addr] == nil || !m[addr].IsEqual(pub) {
+		t.Fatalf("map did not contain pubkey")
+	}
+}
+
+func TestMemoryDepositStoreUpdateDeposits(t *testing.T) {
+	storeIface, _ := CreateDepositStore(&coinparam.BitcoinParams)
+	store := storeIface.(*MemoryDepositStore)
+
+	priv, _ := koblitz.PrivKeyFromBytes(koblitz.S256(), []byte{2})
+	pub := priv.PubKey()
+	addr := "addr2"
+	_ = store.RegisterUser(pub, addr)
+
+	dep := match.Deposit{
+		Pubkey:              pub,
+		Address:             addr,
+		Amount:              100,
+		Txid:                "tx",
+		CoinType:            &coinparam.BitcoinParams,
+		BlockHeightReceived: 5,
+		Confirmations:       2,
+	}
+
+	execs, err := store.UpdateDeposits([]match.Deposit{dep}, 5)
+	if err != nil {
+		t.Fatalf("update deposits: %v", err)
+	}
+	if len(execs) != 0 {
+		t.Fatalf("expected no execs yet")
+	}
+
+	execs, err = store.UpdateDeposits(nil, 7)
+	if err != nil {
+		t.Fatalf("second update: %v", err)
+	}
+	if len(execs) != 1 {
+		t.Fatalf("expected execs on confirmation")
+	}
+	if execs[0].Amount != 100 {
+		t.Fatalf("incorrect exec amount")
+	}
+	var exp [33]byte
+	copy(exp[:], pub.SerializeCompressed())
+	if execs[0].Pubkey != exp {
+		t.Fatalf("incorrect exec pubkey")
+	}
+}


### PR DESCRIPTION
## Summary
- implement memory-based DepositStore to avoid SQL requirement
- register memory store usage when running in memory mode
- add tests for DepositStore registration and deposit updates

## Testing
- `go test ./...` *(fails: modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68536dcd255c832db821c510b3b88bee