### PR TITLE
Complete asset commitment logic

### DIFF
--- a/crypto/README.md
+++ b/crypto/README.md
@@ -1,3 +1,14 @@
 # crypto
 
-The crypto package currently has an interface for Timelock Puzzles, and an implementation of both the RCW96 timelock puzzle and a simple hash-based timelock puzzle. In the case of the hash-based timelock puzzle, it takes just as long to create the puzzle (if you are encrypting information with the result) as it does to solve it. With RCW96, this is not the case. It's supposed to be similar to interact with as the golang built-in `crypto` library.
+The crypto package contains primitives used throughout the project.  It includes
+implementations of several timelock puzzle schemes and utilities for producing
+cryptographic proofs.
+
+## Proof of Assets
+
+The `provisions` subpackage implements a privacy preserving proof of reserves
+protocol.  The exchange commits to the balance of each owned address and then
+publishes a Pedersen commitment to the sum of all balances.  Third parties can
+challenge the exchange to open individual commitments which proves that the
+aggregate commitment matches the on‑chain funds without revealing the complete
+set of addresses.

--- a/crypto/provisions/assets_test.go
+++ b/crypto/provisions/assets_test.go
@@ -1,0 +1,65 @@
+package provisions
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	"math/big"
+
+	"github.com/mit-dci/zksigma"
+)
+
+// helper to set balance in the internal map
+func setBalance(pk *ecdsa.PublicKey, amt uint64) {
+	key := string(elliptic.Marshal(pk.Curve, pk.X, pk.Y))
+	balanceMtx.Lock()
+	balanceMap[key] = amt
+	balanceMtx.Unlock()
+}
+
+func TestBalRetrieval(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("error generating key: %v", err)
+	}
+
+	setBalance(&priv.PublicKey, 12345)
+	bal, err := bal(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("bal returned error: %v", err)
+	}
+	if bal != 12345 {
+		t.Fatalf("expected 12345 got %d", bal)
+	}
+}
+
+func TestCalculateAssetCommitment(t *testing.T) {
+	curve := zksigma.TestCurve.C
+	machine, err := NewAssetsProofMachine(curve)
+	if err != nil {
+		t.Fatalf("error creating machine: %v", err)
+	}
+
+	priv1, _ := ecdsa.GenerateKey(curve, rand.Reader)
+	priv2, _ := ecdsa.GenerateKey(curve, rand.Reader)
+
+	machine.pkAnonSetMutex.Lock()
+	machine.PubKeyAnonSet[&priv1.PublicKey] = priv1
+	machine.PubKeyAnonSet[&priv2.PublicKey] = nil
+	machine.pkAnonSetMutex.Unlock()
+
+	setBalance(&priv1.PublicKey, 1000)
+	setBalance(&priv2.PublicKey, 2000)
+
+	commit, err := machine.CalculateAssetCommitment()
+	if err != nil {
+		t.Fatalf("error calculating asset commitment: %v", err)
+	}
+
+	expected := big.NewInt(1000)
+	if !zksigma.Open(zksigma.TestCurve, expected, machine.assetRand, *commit) {
+		t.Fatalf("commitment did not open with expected value")
+	}
+}


### PR DESCRIPTION
## Summary
- make balance retrieval map based
- compute the asset commitment using Pedersen commitments
- test bal retrieval and asset commitment calculations
- document asset proof process

## Testing
- `go test ./crypto/provisions -run Test -v`


------
https://chatgpt.com/codex/tasks/task_e_68536dd2b78c832dbe35bf16d2acf904