### PR TITLE
Implement memory orderbook

### DIFF
--- a/cxdb/README.md
+++ b/cxdb/README.md
@@ -54,3 +54,8 @@ DepositStore stores the mapping from pubkey to deposit address. This also keeps 
 
 Some old code still exists in `cxdbmemory`.
 The issues related to refactoring cxdb are [#16](https://github.com/mit-dci/opencx/issues/16).
+
+### In-memory Orderbook
+The memory backed orderbook (`cxdbmemory`) keeps all orders in process memory and
+does not persist data to disk. Any orders placed will be lost when the process
+terminates. This implementation is intended only for tests and demonstrations.

--- a/cxdb/cxdbmemory/auctionorderbook.go
+++ b/cxdb/cxdbmemory/auctionorderbook.go
@@ -2,6 +2,7 @@ package cxdbmemory
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/mit-dci/lit/crypto/koblitz"
 	"github.com/mit-dci/opencx/logging"
@@ -10,7 +11,9 @@ import (
 
 // MemoryAuctionOrderbook is the representation of a auction orderbook for SQL
 type MemoryAuctionOrderbook struct {
-	// TODO: implement this
+	// orders is a map from auction id to a map of price -> list of orders
+	orders  map[match.AuctionID]map[float64][]*match.AuctionOrderIDPair
+	bookMtx *sync.Mutex
 
 	// this pair
 	pair *match.Pair
@@ -20,7 +23,9 @@ type MemoryAuctionOrderbook struct {
 func CreateAuctionOrderbook(pair *match.Pair) (book match.AuctionOrderbook, err error) {
 	// Set values for auction engine
 	mo := &MemoryAuctionOrderbook{
-		pair: pair,
+		pair:    pair,
+		orders:  make(map[match.AuctionID]map[float64][]*match.AuctionOrderIDPair),
+		bookMtx: new(sync.Mutex),
 	}
 	// We can connect, now set return
 	book = mo
@@ -29,50 +34,158 @@ func CreateAuctionOrderbook(pair *match.Pair) (book match.AuctionOrderbook, err 
 
 // UpdateBookExec takes in an order execution and updates the orderbook.
 func (mo *MemoryAuctionOrderbook) UpdateBookExec(exec *match.OrderExecution) (err error) {
-	// TODO: Implement
-	logging.Fatalf("UNIMPLEMENTED!")
+	mo.bookMtx.Lock()
+	defer mo.bookMtx.Unlock()
+
+	for aucID, priceMap := range mo.orders {
+		for pr, pairList := range priceMap {
+			for idx, pair := range pairList {
+				if pair.OrderID == exec.OrderID {
+					if exec.Filled {
+						// remove
+						last := len(pairList) - 1
+						pairList[idx] = pairList[last]
+						mo.orders[aucID][pr] = pairList[:last]
+						if len(mo.orders[aucID][pr]) == 0 {
+							delete(mo.orders[aucID], pr)
+						}
+					} else {
+						pair.Order.AmountHave = exec.NewAmountHave
+						pair.Order.AmountWant = exec.NewAmountWant
+					}
+					return
+				}
+			}
+		}
+	}
+	err = fmt.Errorf("order not found")
 	return
 }
 
 // UpdateBookCancel takes in an order cancellation and updates the orderbook.
 func (mo *MemoryAuctionOrderbook) UpdateBookCancel(cancel *match.CancelledOrder) (err error) {
-	// TODO: Implement
-	logging.Fatalf("UNIMPLEMENTED!")
+	mo.bookMtx.Lock()
+	defer mo.bookMtx.Unlock()
+
+	for aucID, priceMap := range mo.orders {
+		for pr, pairList := range priceMap {
+			for idx, pair := range pairList {
+				if pair.OrderID == *cancel.OrderID {
+					last := len(pairList) - 1
+					pairList[idx] = pairList[last]
+					mo.orders[aucID][pr] = pairList[:last]
+					if len(mo.orders[aucID][pr]) == 0 {
+						delete(mo.orders[aucID], pr)
+					}
+					return
+				}
+			}
+		}
+	}
+
+	err = fmt.Errorf("order not found")
 	return
 }
 
 // UpdateBookPlace takes in an order, ID, auction ID, and adds the order to the orderbook.
 func (mo *MemoryAuctionOrderbook) UpdateBookPlace(auctionIDPair *match.AuctionOrderIDPair) (err error) {
-	// TODO: Implement
-	logging.Fatalf("UNIMPLEMENTED!")
+	mo.bookMtx.Lock()
+	defer mo.bookMtx.Unlock()
+
+	aid := auctionIDPair.Order.AuctionID
+	pr := auctionIDPair.Price
+
+	if _, ok := mo.orders[aid]; !ok {
+		mo.orders[aid] = make(map[float64][]*match.AuctionOrderIDPair)
+	}
+	mo.orders[aid][pr] = append(mo.orders[aid][pr], auctionIDPair)
 	return
 }
 
 // GetOrder gets an order from an OrderID
 func (mo *MemoryAuctionOrderbook) GetOrder(orderID *match.OrderID) (aucOrder *match.AuctionOrderIDPair, err error) {
-	// TODO: Implement
-	logging.Fatalf("UNIMPLEMENTED!")
+	mo.bookMtx.Lock()
+	defer mo.bookMtx.Unlock()
+
+	for _, priceMap := range mo.orders {
+		for _, pairList := range priceMap {
+			for _, pair := range pairList {
+				if pair.OrderID == *orderID {
+					aucOrder = pair
+					return
+				}
+			}
+		}
+	}
+	err = fmt.Errorf("order not found")
 	return
 }
 
 // CalculatePrice takes in a pair and returns the calculated price based on the orderbook.
 func (mo *MemoryAuctionOrderbook) CalculatePrice(auctionID *match.AuctionID) (price float64, err error) {
-	// TODO: Implement
-	logging.Fatalf("UNIMPLEMENTED!")
+	mo.bookMtx.Lock()
+	defer mo.bookMtx.Unlock()
+
+	orderMap, ok := mo.orders[*auctionID]
+	if !ok {
+		err = fmt.Errorf("auction not found")
+		return
+	}
+
+	var maxSell float64
+	var minBuy float64
+	minBuy = 0
+	firstBuy := true
+	for pr, list := range orderMap {
+		for _, pair := range list {
+			if pair.Order.IsSellSide() {
+				if pr > maxSell {
+					maxSell = pr
+				}
+			} else if pair.Order.IsBuySide() {
+				if firstBuy || pr < minBuy {
+					minBuy = pr
+					firstBuy = false
+				}
+			}
+		}
+	}
+	price = (minBuy + maxSell) / 2
 	return
 }
 
 // GetOrdersForPubkey gets orders for a specific pubkey.
 func (mo *MemoryAuctionOrderbook) GetOrdersForPubkey(pubkey *koblitz.PublicKey) (orders map[float64][]*match.AuctionOrderIDPair, err error) {
-	// TODO: Implement
-	logging.Fatalf("UNIMPLEMENTED!")
+	orders = make(map[float64][]*match.AuctionOrderIDPair)
+	mo.bookMtx.Lock()
+	defer mo.bookMtx.Unlock()
+
+	var pk [33]byte
+	copy(pk[:], pubkey.SerializeCompressed())
+
+	for _, priceMap := range mo.orders {
+		for pr, pairList := range priceMap {
+			for _, pair := range pairList {
+				if pair.Order.Pubkey == pk {
+					orders[pr] = append(orders[pr], pair)
+				}
+			}
+		}
+	}
 	return
 }
 
 // ViewAuctionOrderbook takes in a trading pair and returns the orderbook as a map
 func (mo *MemoryAuctionOrderbook) ViewAuctionOrderBook() (book map[float64][]*match.AuctionOrderIDPair, err error) {
-	// TODO: Implement
-	logging.Fatalf("UNIMPLEMENTED!")
+	book = make(map[float64][]*match.AuctionOrderIDPair)
+	mo.bookMtx.Lock()
+	defer mo.bookMtx.Unlock()
+
+	for _, priceMap := range mo.orders {
+		for pr, pairList := range priceMap {
+			book[pr] = append(book[pr], pairList...)
+		}
+	}
 	return
 }
 

--- a/cxdb/cxdbmemory/auctionorderbook_test.go
+++ b/cxdb/cxdbmemory/auctionorderbook_test.go
@@ -1,0 +1,110 @@
+package cxdbmemory
+
+import (
+	"testing"
+
+	"github.com/mit-dci/lit/coinparam"
+	"github.com/mit-dci/lit/crypto/koblitz"
+	"golang.org/x/crypto/sha3"
+
+	"github.com/mit-dci/opencx/match"
+)
+
+func createTestOrder(t *testing.T, pair *match.Pair) (*match.AuctionOrderIDPair, *koblitz.PublicKey) {
+	priv, err := koblitz.NewPrivateKey(koblitz.S256())
+	if err != nil {
+		t.Fatalf("key gen err: %v", err)
+	}
+	pub := priv.PubKey()
+
+	order := &match.AuctionOrder{
+		TradingPair: *pair,
+		Side:        match.Buy,
+		AmountHave:  1000,
+		AmountWant:  2000,
+		AuctionID:   match.AuctionID{0x01},
+		Nonce:       [2]byte{0x01, 0x02},
+	}
+	copy(order.Pubkey[:], pub.SerializeCompressed())
+	pr, _ := order.Price()
+	id := sha3.Sum256(order.SerializeSignable())
+	pairStruct := &match.AuctionOrderIDPair{OrderID: id, Order: order, Price: pr}
+	return pairStruct, pub
+}
+
+func TestMemoryAuctionOrderbookPlaceGet(t *testing.T) {
+	btc, _ := match.AssetFromCoinParam(&coinparam.RegressionNetParams)
+	ltc, _ := match.AssetFromCoinParam(&coinparam.LiteRegNetParams)
+	pair := &match.Pair{AssetWant: btc, AssetHave: ltc}
+
+	bookInt, err := CreateAuctionOrderbook(pair)
+	if err != nil {
+		t.Fatalf("create orderbook: %v", err)
+	}
+	book := bookInt.(*MemoryAuctionOrderbook)
+
+	orderPair, _ := createTestOrder(t, pair)
+	if err = book.UpdateBookPlace(orderPair); err != nil {
+		t.Fatalf("place err: %v", err)
+	}
+
+	got, err := book.GetOrder(&orderPair.OrderID)
+	if err != nil {
+		t.Fatalf("get order err: %v", err)
+	}
+	if got.OrderID != orderPair.OrderID {
+		t.Errorf("order id mismatch")
+	}
+}
+
+func TestMemoryAuctionOrderbookCancel(t *testing.T) {
+	btc, _ := match.AssetFromCoinParam(&coinparam.RegressionNetParams)
+	ltc, _ := match.AssetFromCoinParam(&coinparam.LiteRegNetParams)
+	pair := &match.Pair{AssetWant: btc, AssetHave: ltc}
+
+	bookInt, err := CreateAuctionOrderbook(pair)
+	if err != nil {
+		t.Fatalf("create orderbook: %v", err)
+	}
+	book := bookInt.(*MemoryAuctionOrderbook)
+
+	orderPair, _ := createTestOrder(t, pair)
+	if err = book.UpdateBookPlace(orderPair); err != nil {
+		t.Fatalf("place err: %v", err)
+	}
+
+	cancel := &match.CancelledOrder{OrderID: &orderPair.OrderID}
+	if err = book.UpdateBookCancel(cancel); err != nil {
+		t.Fatalf("cancel err: %v", err)
+	}
+
+	if _, err = book.GetOrder(&orderPair.OrderID); err == nil {
+		t.Errorf("expected error retrieving cancelled order")
+	}
+}
+
+func TestMemoryAuctionOrderbookOrdersForPubkey(t *testing.T) {
+	btc, _ := match.AssetFromCoinParam(&coinparam.RegressionNetParams)
+	ltc, _ := match.AssetFromCoinParam(&coinparam.LiteRegNetParams)
+	pair := &match.Pair{AssetWant: btc, AssetHave: ltc}
+
+	bookInt, err := CreateAuctionOrderbook(pair)
+	if err != nil {
+		t.Fatalf("create orderbook: %v", err)
+	}
+	book := bookInt.(*MemoryAuctionOrderbook)
+
+	orderPair, pub := createTestOrder(t, pair)
+	if err = book.UpdateBookPlace(orderPair); err != nil {
+		t.Fatalf("place err: %v", err)
+	}
+
+	orders, err := book.GetOrdersForPubkey(pub)
+	if err != nil {
+		t.Fatalf("get orders err: %v", err)
+	}
+	pr := orderPair.Price
+	if list, ok := orders[pr]; !ok || len(list) != 1 {
+		t.Errorf("order for pubkey not found")
+	}
+}


### PR DESCRIPTION
## Summary
- implement in-memory auction orderbook
- add tests for basic placement, cancellation and retrieval
- document limitations of in-memory orderbook

## Testing
- `go test ./...` *(fails: module download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68536d9d88f4832d9ac45e47a94cbec1