### PR TITLE
Add simple web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ go build ./cmd/ocx/...
 
 You can now issue any of the commands in the cxrpc README.md file.
 
+## Running opencx Web UI
+
+```sh
+go build ./cmd/webui/...
+./webui
+```
+
+
 ## Configuration
 
 There are configuration options (both command line and .conf) for the client and the server, and by default home folders for these files will be created at `~/.opencx/opencxd/` and `~/.opencx/ocx/` respectively. You can decide whether or not to use the

--- a/cmd/webui/README.md
+++ b/cmd/webui/README.md
@@ -1,0 +1,14 @@
+# webui
+
+**webui** provides a very small web interface for OpenCX. It exposes a few RPC
+methods over HTTP and serves a basic HTML page to display the orderbook.
+
+Run it with:
+
+```sh
+go build ./cmd/webui/...
+./webui
+```
+
+The server listens on port `8080` by default and assumes the exchange RPC server
+is reachable on `localhost:12345`.

--- a/cmd/webui/static/index.html
+++ b/cmd/webui/static/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>OpenCX Web UI</title>
+<style>
+body { font-family: sans-serif; }
+table { border-collapse: collapse; margin-top: 10px; }
+th, td { border: 1px solid #ccc; padding: 4px; }
+</style>
+</head>
+<body>
+<h1>OpenCX Web UI</h1>
+<div>
+<label for="pairSelect">Trading Pair:</label>
+<select id="pairSelect"></select>
+<button id="refreshBtn">Refresh</button>
+</div>
+<div id="price"></div>
+<table id="orderbook">
+<thead><tr><th>Side</th><th>Price</th><th>Amount</th></tr></thead>
+<tbody></tbody>
+</table>
+<script>
+async function loadPairs() {
+  const res = await fetch('/api/pairs');
+  const pairs = await res.json();
+  const sel = document.getElementById('pairSelect');
+  sel.innerHTML = '';
+  pairs.forEach(p => {
+    const opt = document.createElement('option');
+    opt.value = p; opt.textContent = p; sel.appendChild(opt);
+  });
+  if (pairs.length) refresh();
+}
+async function refresh() {
+  const pair = document.getElementById('pairSelect').value;
+  if (!pair) return;
+  const priceRes = await fetch('/api/price?pair=' + encodeURIComponent(pair));
+  const price = await priceRes.json();
+  document.getElementById('price').textContent = 'Price: ' + price;
+
+  const res = await fetch('/api/orderbook?pair=' + encodeURIComponent(pair));
+  const book = await res.json();
+  const tbody = document.querySelector('#orderbook tbody');
+  tbody.innerHTML = '';
+  Object.keys(book).forEach(k => {
+    book[k].forEach(o => {
+      const tr = document.createElement('tr');
+      const side = document.createElement('td');
+      side.textContent = o.limitorder.side ? 'buy' : 'sell';
+      const priceTd = document.createElement('td');
+      priceTd.textContent = k;
+      const amt = document.createElement('td');
+      amt.textContent = o.limitorder.amounthave;
+      tr.appendChild(side); tr.appendChild(priceTd); tr.appendChild(amt);
+      tbody.appendChild(tr);
+    });
+  });
+}
+document.getElementById('refreshBtn').addEventListener('click', refresh);
+window.onload = loadPairs;
+</script>
+</body>
+</html>

--- a/cmd/webui/webui.go
+++ b/cmd/webui/webui.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+
+	"github.com/mit-dci/opencx/benchclient"
+	"github.com/mit-dci/opencx/logging"
+)
+
+var client benchclient.BenchClient
+
+func orderbookHandler(w http.ResponseWriter, r *http.Request) {
+	pair := r.URL.Query().Get("pair")
+	if pair == "" {
+		http.Error(w, "missing pair", http.StatusBadRequest)
+		return
+	}
+	reply, err := client.ViewOrderbook(pair)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(reply.Orderbook)
+}
+
+func pairsHandler(w http.ResponseWriter, r *http.Request) {
+	reply, err := client.GetPairs()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(reply.PairList)
+}
+
+func priceHandler(w http.ResponseWriter, r *http.Request) {
+	pair := r.URL.Query().Get("pair")
+	if pair == "" {
+		http.Error(w, "missing pair", http.StatusBadRequest)
+		return
+	}
+	reply, err := client.GetPrice(pair)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(reply.Price)
+}
+
+func main() {
+	var rpchost string
+	var rpcport uint
+	var webport uint
+
+	flag.StringVar(&rpchost, "rpchost", "localhost", "RPC server host")
+	flag.UintVar(&rpcport, "rpcport", 12345, "RPC server port")
+	flag.UintVar(&webport, "webport", 8080, "web interface port")
+	flag.Parse()
+
+	if err := client.SetupBenchClient(rpchost, uint16(rpcport)); err != nil {
+		logging.Fatalf("Error setting up RPC client: %v", err)
+	}
+
+	http.HandleFunc("/api/orderbook", orderbookHandler)
+	http.HandleFunc("/api/pairs", pairsHandler)
+	http.HandleFunc("/api/price", priceHandler)
+	http.Handle("/", http.FileServer(http.Dir("cmd/webui/static")))
+
+	addr := fmt.Sprintf(":%d", webport)
+	logging.Infof("Web UI listening on %s", addr)
+	logging.Fatal(http.ListenAndServe(addr, nil))
+}


### PR DESCRIPTION
## Summary
- add a small web UI command with an HTTP server
- serve an HTML page that lists trading pairs and shows orderbooks
- document how to build and run the web UI

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68536fee0a20832d927b35a8472900d5