### PR TITLE
Add comments to clarify key packages

### DIFF
--- a/benchclient/benchclient.go
+++ b/benchclient/benchclient.go
@@ -1,3 +1,6 @@
+// Package benchclient contains a simple RPC client implementation used
+// in benchmarks and integration tests.  It wraps the RPC transport and
+// exposes helper methods for the various exchange commands.
 package benchclient
 
 import (

--- a/chainutils/hostparams.go
+++ b/chainutils/hostparams.go
@@ -1,3 +1,6 @@
+// Package chainutils provides helper types and utility functions for
+// constructing chain- and host-related configuration structures used
+// throughout the exchange.
 package chainutils
 
 import (

--- a/cmd/opencxd/opencxd.go
+++ b/cmd/opencxd/opencxd.go
@@ -1,3 +1,6 @@
+// Opencxd is the main binary for running the OpenCX exchange daemon. It
+// initializes all required subsystems and exposes an RPC interface for
+// clients.
 package main
 
 import (
@@ -102,6 +105,8 @@ func newConfigParser(conf *opencxConfig, options flags.Options) *flags.Parser {
 	return parser
 }
 
+// main is the entry point for the daemon. It loads configuration,
+// sets up all supporting services and then waits for RPC requests.
 func main() {
 	memguard.CatchInterrupt()
 	defer memguard.Purge()
@@ -123,7 +128,8 @@ func main() {
 	// Check and load config params
 	key := opencxSetup(&conf)
 
-	// Generate the coin list based on the parameters we know
+	// Build the list of coins the server will support from the
+	// command-line configuration.
 	coinList := generateCoinList(&conf)
 
 	var pairList []*match.Pair
@@ -175,6 +181,8 @@ func main() {
 		logging.Fatalf("Error creating limit orderbook map for opencxd: %s", err)
 	}
 
+	// Each coin requires its own persistent deposit store where
+	// on-chain funds can be tracked.
 	logging.Infof("Creating deposit stores...")
 	var depositStores map[*coinparam.Params]cxdb.DepositStore
 	if len(conf.Whitelist) != 0 {

--- a/cmd/opencxd/opencxdinit.go
+++ b/cmd/opencxd/opencxdinit.go
@@ -178,6 +178,9 @@ func opencxSetup(conf *opencxConfig) *[32]byte {
 	return privkey
 }
 
+// obtainPassword returns a LockedBuffer containing the key password.
+// The value can be provided via stdin, environment variable or directly
+// on the command line in that order of preference.
 func obtainPassword(conf *opencxConfig) (*memguard.LockedBuffer, error) {
 	if conf.KeyPasswordPipe {
 		data, err := io.ReadAll(os.Stdin)
@@ -198,10 +201,16 @@ func obtainPassword(conf *opencxConfig) (*memguard.LockedBuffer, error) {
 	return nil, nil
 }
 
+// generateCoinList derives the list of coin parameters from the command
+// line configuration.  It reuses generateHostParams and strips the host
+// information.
 func generateCoinList(conf *opencxConfig) []*coinparam.Params {
 	return util.HostParamList(generateHostParams(conf)).CoinListFromHostParams()
 }
 
+// generateHostParams constructs a list of HostParams based on the
+// configured network options.  Only entries with a host specified are
+// included in the result.
 func generateHostParams(conf *opencxConfig) (hostParamList []*util.HostParams) {
 	// Regular networks (Just like don't use any of these, I support them though)
 	if conf.Btchost != "" {

--- a/cxrpc/listener.go
+++ b/cxrpc/listener.go
@@ -1,3 +1,6 @@
+// Package cxrpc also contains utilities for creating RPC listeners on
+// the server side.  These helpers hide the Noise and standard RPC
+// setup so callers only need to provide the server instance.
 package cxrpc
 
 import (
@@ -11,6 +14,9 @@ import (
 	"github.com/mit-dci/opencx/logging"
 )
 
+// CreateRPCForServer prepares an RPC caller instance that is ready to
+// expose the server's methods over either plain RPC or Noise based
+// transports.
 func CreateRPCForServer(server *cxserver.OpencxServer) (rpc1 *OpencxRPCCaller, err error) {
 	rpc1 = &OpencxRPCCaller{
 		caller: &OpencxRPC{

--- a/cxrpc/opencxclient.go
+++ b/cxrpc/opencxclient.go
@@ -1,3 +1,6 @@
+// Package cxrpc implements the RPC client interfaces used by the
+// exchange. Clients can communicate with the server using either plain
+// RPC or an authenticated Noise-based transport.
 package cxrpc
 
 import (
@@ -25,6 +28,9 @@ type OpencxRPCClient struct {
 }
 
 // OpencxNoiseClient is an authenticated RPC Client for the opencx Server
+// OpencxNoiseClient wraps a standard rpc.Client and uses Noise for
+// transport-layer authentication.  The embedded private key is used to
+// establish the Noise session.
 type OpencxNoiseClient struct {
 	Conn *rpc.Client
 	key  *koblitz.PrivateKey


### PR DESCRIPTION
## Summary
- document benchclient and chainutils packages
- add package-level comments for RPC helpers
- provide additional context in opencxd daemon
- explain helper functions in init code

## Testing
- `go test ./...` *(fails: Forbidden when fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_68537437b7bc832d82db7c2d7094f590